### PR TITLE
Fixed the order of confirmation sending

### DIFF
--- a/src/bungee/me/RockinChaos/cloudsync/listeners/Messages.java
+++ b/src/bungee/me/RockinChaos/cloudsync/listeners/Messages.java
@@ -45,8 +45,8 @@ public class Messages implements Listener {
             try {
                 final ProxiedPlayer player = CloudSync.getInstance().getProxy().getPlayer(stream.readUTF());
                 final String command = stream.readUTF();
-                this.sendConfirmation(CloudSync.getInstance().getProxy().getPlayer(event.getReceiver().toString()).getServer().getInfo());
                 CloudSync.getInstance().getProxy().getPluginManager().dispatchCommand(player, command);
+                this.sendConfirmation(CloudSync.getInstance().getProxy().getPlayer(event.getReceiver().toString()).getServer().getInfo());
             } catch (Exception e) { ServerUtils.sendSevereTrace(e); }
         }
     }

--- a/src/velocity/me/RockinChaos/cloudsync/listeners/Messages.java
+++ b/src/velocity/me/RockinChaos/cloudsync/listeners/Messages.java
@@ -43,8 +43,8 @@ public class Messages {
                 final Player player = CloudSync.getProxy().getPlayer(stream.readUTF()).get();
                 final String command = stream.readUTF();
                 ServerConnection connection = (ServerConnection) event.getSource();
-                this.sendConfirmation(connection);
                 CloudSync.getProxy().getCommandManager().executeImmediatelyAsync(player, command);
+                this.sendConfirmation(connection);
             } catch (Exception e) { ServerUtils.sendSevereTrace(e); }
         }
     }


### PR DESCRIPTION
# Description
Basically if dispatching command fails, no confirmation will be sent.

Fixes # (issue)
if the player disconnects right before the message reaches the proxy, it will cause a big line of error

## Type of change

Please delete options that are not relevant.

- [ V] Bug fix (non-breaking change which fixes an issue)
- [ N] New feature (non-breaking change which adds functionality)
- [ N] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ N] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Server version: any
* Java version: any
* Plugin configurations: any

# Checklist:

- [Y ] My code follows the style guidelines of this project
- [ Y] I have performed a self-review of my own code
- [ Y] I have commented my code, particularly in hard-to-understand areas
- [ N] I have made corresponding changes to the documentation
- [ Y] My changes generate no new warnings
- [ Y] I have added tests that prove my fix is effective or that my feature works
- [ Y] New and existing unit tests pass locally with my changes
- [ idk] Any dependent changes have been merged and published in downstream modules